### PR TITLE
Added Mechi Multiple Campus TU Nepal

### DIFF
--- a/lib/domains/de/rvwbk.txt
+++ b/lib/domains/de/rvwbk.txt
@@ -1,0 +1,1 @@
+Richard-von-Weizsäcker-Berufskolleg


### PR DESCRIPTION
Mechi Multiple Campus uses https://mechicampus.edu.np/ as official website and uses meme.tu.edu.np as domain for email provided to students.
Mechi Multiple Campus is a constituent campus of Tribhuvan University. Tribhuvan University uses http://tribhuvan-university.edu.np/ or http://tu.edu.np/ as official wensite.